### PR TITLE
refactor: 引入 Zustand 替代 props drilling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "remark-math": "^6.0.0",
         "turndown": "^7.2.0",
         "turndown-plugin-gfm": "^1.0.2",
-        "xlsx": "^0.18.5"
+        "xlsx": "^0.18.5",
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -16814,6 +16815,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "remark-math": "^6.0.0",
     "turndown": "^7.2.0",
     "turndown-plugin-gfm": "^1.0.2",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/hooks/app/props/useAppModalsProps.ts
+++ b/src/hooks/app/props/useAppModalsProps.ts
@@ -1,0 +1,105 @@
+import { useMemo } from 'react';
+import { useAppLogic } from '../useAppLogic';
+import { DEFAULT_CHAT_SETTINGS } from '../../../constants/appConstants';
+import { ChatSettings } from '../../../types';
+import { useUIStore } from '../../../stores/uiStore';
+
+export const useAppModalsProps = (logic: ReturnType<typeof useAppLogic>) => {
+  const {
+    appSettings,
+    chatState,
+    eventsState,
+    dataManagement,
+    t,
+    handleSaveSettings,
+    setIsExportModalOpen,
+    isExportModalOpen,
+    handleExportChat,
+    exportStatus,
+  } = logic;
+
+  const isSettingsModalOpen = useUIStore((s) => s.isSettingsModalOpen);
+  const setIsSettingsModalOpen = useUIStore((s) => s.setIsSettingsModalOpen);
+  const isPreloadedMessagesModalOpen = useUIStore((s) => s.isPreloadedMessagesModalOpen);
+  const setIsPreloadedMessagesModalOpen = useUIStore((s) => s.setIsPreloadedMessagesModalOpen);
+  const isLogViewerOpen = useUIStore((s) => s.isLogViewerOpen);
+  const setIsLogViewerOpen = useUIStore((s) => s.setIsLogViewerOpen);
+
+  // Merge active chat settings into app settings for the modal so controls reflect current session
+  const settingsForModal = useMemo(() => {
+    if (chatState.activeSessionId && chatState.currentChatSettings) {
+        const cleanSessionOverrides: any = {};
+
+        (Object.keys(DEFAULT_CHAT_SETTINGS) as Array<keyof ChatSettings>).forEach(key => {
+             if (Object.prototype.hasOwnProperty.call(chatState.currentChatSettings, key)) {
+                 cleanSessionOverrides[key] = (chatState.currentChatSettings as any)[key];
+             }
+        });
+
+        return {
+            ...appSettings,
+            ...cleanSessionOverrides
+        };
+    }
+    return appSettings;
+  }, [appSettings, chatState.currentChatSettings, chatState.activeSessionId]);
+
+  return useMemo(() => ({
+    isSettingsModalOpen,
+    setIsSettingsModalOpen,
+    appSettings: settingsForModal,
+    availableModels: chatState.apiModels,
+    handleSaveSettings,
+    clearCacheAndReload: chatState.clearCacheAndReload,
+    clearAllHistory: chatState.clearAllHistory,
+    handleInstallPwa: eventsState.handleInstallPwa,
+    installPromptEvent: eventsState.installPromptEvent,
+    isStandalone: eventsState.isStandalone,
+    handleImportSettings: dataManagement.handleImportSettings,
+    handleExportSettings: dataManagement.handleExportSettings,
+    handleImportHistory: dataManagement.handleImportHistory,
+    handleExportHistory: dataManagement.handleExportHistory,
+    handleImportAllScenarios: dataManagement.handleImportAllScenarios,
+    handleExportAllScenarios: dataManagement.handleExportAllScenarios,
+    isPreloadedMessagesModalOpen,
+    setIsPreloadedMessagesModalOpen,
+    savedScenarios: chatState.savedScenarios,
+    handleSaveAllScenarios: chatState.handleSaveAllScenarios,
+    handleLoadPreloadedScenario: chatState.handleLoadPreloadedScenario,
+    isExportModalOpen,
+    setIsExportModalOpen,
+    handleExportChat,
+    exportStatus,
+    isLogViewerOpen,
+    setIsLogViewerOpen,
+    currentChatSettings: chatState.currentChatSettings,
+    t,
+    setAvailableModels: chatState.setApiModels,
+  }), [
+    isSettingsModalOpen,
+    setIsSettingsModalOpen,
+    settingsForModal,
+    chatState.apiModels,
+    chatState.clearCacheAndReload,
+    chatState.clearAllHistory,
+    chatState.savedScenarios,
+    chatState.handleSaveAllScenarios,
+    chatState.handleLoadPreloadedScenario,
+    chatState.currentChatSettings,
+    chatState.setApiModels,
+    handleSaveSettings,
+    eventsState.handleInstallPwa,
+    eventsState.installPromptEvent,
+    eventsState.isStandalone,
+    dataManagement,
+    isPreloadedMessagesModalOpen,
+    setIsPreloadedMessagesModalOpen,
+    isExportModalOpen,
+    setIsExportModalOpen,
+    handleExportChat,
+    exportStatus,
+    isLogViewerOpen,
+    setIsLogViewerOpen,
+    t,
+  ]);
+};

--- a/src/hooks/app/props/useChatAreaProps.ts
+++ b/src/hooks/app/props/useChatAreaProps.ts
@@ -1,0 +1,270 @@
+import { useMemo, useRef, useLayoutEffect, useCallback } from 'react';
+import { useAppLogic } from '../useAppLogic';
+import { CANVAS_SYSTEM_PROMPT, BBOX_SYSTEM_PROMPT, HD_GUIDE_SYSTEM_PROMPT } from '../../../constants/appConstants';
+import { useUIStore } from '../../../stores/uiStore';
+
+// 核心优化：创建一个永远稳定的回调函数引用
+// 这样可以确保传给 MessageList 和 Message (React.memo) 的函数地址永不改变，彻底阻断无效重渲染
+function useStableCallback<T extends (...args: any[]) => any>(fn: T): T {
+    const ref = useRef<T>(fn);
+    useLayoutEffect(() => {
+        ref.current = fn;
+    });
+    return useCallback((...args: any[]) => {
+        return ref.current(...args);
+    }, []) as T;
+}
+
+export const useChatAreaProps = (logic: ReturnType<typeof useAppLogic>) => {
+  const {
+    appSettings,
+    chatState,
+    pipState,
+    currentTheme,
+    language,
+    t,
+    sessionTitle,
+    handleLoadCanvasPromptAndSave,
+    handleToggleBBoxMode,
+    handleToggleGuideMode,
+    handleSuggestionClick,
+    handleSetThinkingLevel,
+    getCurrentModelDisplayName,
+    handleOpenSidePanel,
+  } = logic;
+
+  // UI state from Zustand store
+  const setIsSettingsModalOpen = useUIStore((s) => s.setIsSettingsModalOpen);
+  const setIsPreloadedMessagesModalOpen = useUIStore((s) => s.setIsPreloadedMessagesModalOpen);
+  const toggleHistorySidebar = useUIStore((s) => s.toggleHistorySidebar);
+  const setIsLogViewerOpen = useUIStore((s) => s.setIsLogViewerOpen);
+  const isHistorySidebarOpen = useUIStore((s) => s.isHistorySidebarOpen);
+
+  // 使用 useStableCallback 包裹所有会传递给子组件的函数
+  const onNewChat = useStableCallback(() => chatState.startNewChat());
+  const onOpenSettingsModal = useStableCallback(() => setIsSettingsModalOpen(true));
+  const onOpenScenariosModal = useStableCallback(() => setIsPreloadedMessagesModalOpen(true));
+  const onToggleHistorySidebar = useStableCallback(() => toggleHistorySidebar());
+  
+  const onLoadCanvasPrompt = useStableCallback(handleLoadCanvasPromptAndSave);
+  const onToggleBBox = useStableCallback(handleToggleBBoxMode);
+  const onToggleGuide = useStableCallback(handleToggleGuideMode);
+  
+  const onScrollContainerScroll = useStableCallback(chatState.onScrollContainerScroll);
+  const onEditMessage = useStableCallback(chatState.handleEditMessage);
+  const onDeleteMessage = useStableCallback(chatState.handleDeleteMessage);
+  const onRetryMessage = useStableCallback(chatState.handleRetryMessage);
+  const onEditMessageContent = useStableCallback(chatState.handleUpdateMessageContent);
+  const onUpdateMessageFile = useStableCallback(chatState.handleUpdateMessageFile);
+  
+  const onSuggestionClickStable = useStableCallback((text: string) => handleSuggestionClick('homepage', text));
+  const onOrganizeInfoClickStable = useStableCallback((text: string) => handleSuggestionClick('organize', text));
+  const onFollowUpSuggestionClickStable = useStableCallback((text: string) => handleSuggestionClick('follow-up', text));
+  
+  const onTextToSpeech = useStableCallback(chatState.handleTextToSpeech);
+  const onGenerateCanvas = useStableCallback(chatState.handleGenerateCanvas);
+  const onContinueGeneration = useStableCallback(chatState.handleContinueGeneration);
+  const onQuickTTS = useStableCallback(chatState.handleQuickTTS);
+  
+  const setCommandedInput = useStableCallback(chatState.setCommandedInput);
+  const onMessageSent = useStableCallback(() => chatState.setCommandedInput(null));
+  const setSelectedFiles = useStableCallback(chatState.setSelectedFiles);
+  const onSendMessage = useStableCallback((text: string, options?: { isFastMode?: boolean }) => chatState.handleSendMessage({ text, ...options }));
+  
+  const setEditingMessageId = useStableCallback(chatState.setEditingMessageId);
+  const onStopGenerating = useStableCallback(chatState.handleStopGenerating);
+  const onCancelEdit = useStableCallback(chatState.handleCancelEdit);
+  const onProcessFiles = useStableCallback(chatState.handleProcessAndAddFiles);
+  const onAddFileById = useStableCallback(chatState.handleAddFileById);
+  const onCancelUpload = useStableCallback(chatState.handleCancelFileUpload);
+  const onTranscribeAudio = useStableCallback(chatState.handleTranscribeAudio);
+  
+  const setAppFileError = useStableCallback(chatState.setAppFileError);
+  const setAspectRatio = useStableCallback(chatState.setAspectRatio);
+  const setImageSize = useStableCallback(chatState.setImageSize);
+  
+  const onToggleGoogleSearch = useStableCallback(chatState.toggleGoogleSearch);
+  const onToggleCodeExecution = useStableCallback(chatState.toggleCodeExecution);
+  const onToggleLocalPython = useStableCallback(chatState.toggleLocalPython);
+  const onToggleUrlContext = useStableCallback(chatState.toggleUrlContext);
+  const onToggleDeepSearch = useStableCallback(chatState.toggleDeepSearch);
+  
+  const onClearChat = useStableCallback(chatState.handleClearCurrentChat);
+  const onOpenSettings = useStableCallback(() => setIsSettingsModalOpen(true));
+  const onToggleCanvasPrompt = useStableCallback(handleLoadCanvasPromptAndSave);
+  const onTogglePinCurrentSession = useStableCallback(chatState.handleTogglePinCurrentSession);
+  const onRetryLastTurn = useStableCallback(chatState.handleRetryLastTurn);
+  const onSelectModel = useStableCallback(chatState.handleSelectModelInHeader);
+  const onEditLastUserMessage = useStableCallback(chatState.handleEditLastUserMessage);
+  const onTogglePip = useStableCallback(pipState.togglePip);
+  const onToggleQuadImages = useStableCallback(() => logic.setAppSettings(prev => ({ ...prev, generateQuadImages: !prev.generateQuadImages })));
+  const onSetThinkingLevel = useStableCallback(handleSetThinkingLevel);
+  const setCurrentChatSettings = useStableCallback(chatState.setCurrentChatSettings);
+  const onOpenSidePanel = useStableCallback(handleOpenSidePanel);
+  const onAddUserMessage = useStableCallback(chatState.handleAddUserMessage);
+  const onLiveTranscript = useStableCallback(chatState.handleLiveTranscript);
+
+  const handleAppDragEnter = useStableCallback(chatState.handleAppDragEnter);
+  const handleAppDragOver = useStableCallback(chatState.handleAppDragOver);
+  const handleAppDragLeave = useStableCallback(chatState.handleAppDragLeave);
+  const handleAppDrop = useStableCallback(chatState.handleAppDrop);
+  const setScrollContainerRef = useStableCallback(chatState.setScrollContainerRef);
+
+  // getCurrentModelDisplayName 是立即求值的，得到的是 string (原始类型)，因此无需包装回调
+  const currentModelName = getCurrentModelDisplayName();
+
+  return useMemo(() => ({
+    activeSessionId: chatState.activeSessionId,
+    sessionTitle,
+    currentChatSettings: chatState.currentChatSettings,
+    setAppFileError,
+    isAppDraggingOver: chatState.isAppDraggingOver,
+    isProcessingDrop: chatState.isProcessingDrop,
+    handleAppDragEnter,
+    handleAppDragOver,
+    handleAppDragLeave,
+    handleAppDrop,
+    onNewChat,
+    onOpenSettingsModal,
+    onOpenScenariosModal,
+    onToggleHistorySidebar,
+    isLoading: chatState.isLoading,
+    currentModelName,
+    availableModels: chatState.apiModels,
+    selectedModelId: chatState.currentChatSettings.modelId || appSettings.modelId,
+    onSelectModel,
+    isSwitchingModel: chatState.isSwitchingModel,
+    isHistorySidebarOpen,
+    onLoadCanvasPrompt,
+    isCanvasPromptActive: chatState.currentChatSettings.systemInstruction === CANVAS_SYSTEM_PROMPT,
+    isBBoxModeActive: chatState.currentChatSettings.systemInstruction === BBOX_SYSTEM_PROMPT,
+    isGuideModeActive: chatState.currentChatSettings.systemInstruction === HD_GUIDE_SYSTEM_PROMPT,
+    onToggleBBox,
+    onToggleGuide,
+    isKeyLocked: !!chatState.currentChatSettings.lockedApiKey,
+    themeId: currentTheme.id,
+    modelsLoadingError: null,
+    messages: chatState.messages,
+    scrollContainerRef: chatState.scrollContainerRef,
+    setScrollContainerRef,
+    onScrollContainerScroll,
+    onEditMessage,
+    onDeleteMessage,
+    onRetryMessage,
+    onEditMessageContent, 
+    onUpdateMessageFile,
+    showThoughts: chatState.currentChatSettings.showThoughts,
+    baseFontSize: appSettings.baseFontSize,
+    expandCodeBlocksByDefault: appSettings.expandCodeBlocksByDefault,
+    isMermaidRenderingEnabled: appSettings.isMermaidRenderingEnabled,
+    isGraphvizRenderingEnabled: appSettings.isGraphvizRenderingEnabled ?? true,
+    onSuggestionClick: onSuggestionClickStable,
+    onOrganizeInfoClick: onOrganizeInfoClickStable,
+    onFollowUpSuggestionClick: onFollowUpSuggestionClickStable,
+    onTextToSpeech,
+    onGenerateCanvas,
+    onContinueGeneration,
+    ttsMessageId: chatState.ttsMessageId,
+    onQuickTTS,
+    language,
+    appSettings,
+    commandedInput: chatState.commandedInput,
+    setCommandedInput,
+    onMessageSent,
+    selectedFiles: chatState.selectedFiles,
+    setSelectedFiles,
+    onSendMessage,
+    isEditing: !!chatState.editingMessageId,
+    editMode: chatState.editMode,
+    editingMessageId: chatState.editingMessageId,
+    setEditingMessageId,
+    onStopGenerating,
+    onCancelEdit,
+    onProcessFiles,
+    onAddFileById,
+    onCancelUpload,
+    onTranscribeAudio,
+    isProcessingFile: chatState.isAppProcessingFile,
+    fileError: chatState.appFileError,
+    isImagenModel: chatState.currentChatSettings.modelId?.includes('imagen'),
+    isImageEditModel: chatState.currentChatSettings.modelId?.includes('image-preview'),
+    aspectRatio: chatState.aspectRatio,
+    setAspectRatio,
+    imageSize: chatState.imageSize,
+    setImageSize,
+    isGoogleSearchEnabled: !!chatState.currentChatSettings.isGoogleSearchEnabled,
+    onToggleGoogleSearch,
+    isCodeExecutionEnabled: !!chatState.currentChatSettings.isCodeExecutionEnabled,
+    onToggleCodeExecution,
+    isLocalPythonEnabled: !!chatState.currentChatSettings.isLocalPythonEnabled,
+    onToggleLocalPython,
+    isUrlContextEnabled: !!chatState.currentChatSettings.isUrlContextEnabled,
+    onToggleUrlContext,
+    isDeepSearchEnabled: !!chatState.currentChatSettings.isDeepSearchEnabled,
+    onToggleDeepSearch,
+    onClearChat,
+    onOpenSettings,
+    onToggleCanvasPrompt,
+    onTogglePinCurrentSession,
+    onRetryLastTurn,
+    onEditLastUserMessage,
+    onOpenLogViewer: () => setIsLogViewerOpen(true),
+    onClearAllHistory: chatState.clearAllHistory,
+    isPipSupported: pipState.isPipSupported && appSettings.useCustomApiConfig,
+    isPipActive: pipState.isPipActive,
+    onTogglePip,
+    generateQuadImages: appSettings.generateQuadImages ?? false,
+    onToggleQuadImages,
+    onSetThinkingLevel,
+    setCurrentChatSettings,
+    onOpenSidePanel,
+    onAddUserMessage,
+    onLiveTranscript,
+    t,
+  }), [
+    // 现在的依赖数组中只剩下纯粹的数据和状态，排除了所有函数
+    chatState.activeSessionId, 
+    sessionTitle,
+    chatState.currentChatSettings, 
+    chatState.isAppDraggingOver, 
+    chatState.isProcessingDrop,
+    chatState.isLoading, 
+    chatState.apiModels, 
+    chatState.isSwitchingModel, 
+    chatState.messages, 
+    chatState.scrollContainerRef,
+    chatState.ttsMessageId, 
+    chatState.commandedInput, 
+    chatState.selectedFiles,
+    chatState.editingMessageId, 
+    chatState.editMode, 
+    chatState.isAppProcessingFile, 
+    chatState.appFileError, 
+    chatState.aspectRatio,
+    chatState.imageSize, 
+
+    pipState.isPipSupported,
+    pipState.isPipActive,
+    
+    appSettings, 
+    currentTheme.id, 
+    language, 
+    t,
+    currentModelName,
+
+    // 依然需要将这些稳定的回调传入依赖数组以满足 React Hook 规则的检测
+    // 但由于上面用 useStableCallback 包装过，它们在组件整个生命周期中都不会改变
+    setAppFileError, handleAppDragEnter, handleAppDragOver, handleAppDragLeave, handleAppDrop,
+    onNewChat, onOpenSettingsModal, onOpenScenariosModal, onToggleHistorySidebar,
+    onSelectModel, onLoadCanvasPrompt, onToggleBBox, onToggleGuide,
+    setScrollContainerRef, onScrollContainerScroll, onEditMessage, onDeleteMessage, onRetryMessage,
+    onEditMessageContent, onUpdateMessageFile, onSuggestionClickStable, onOrganizeInfoClickStable, onFollowUpSuggestionClickStable,
+    onTextToSpeech, onGenerateCanvas, onContinueGeneration, onQuickTTS, setCommandedInput, onMessageSent,
+    setSelectedFiles, onSendMessage, setEditingMessageId, onStopGenerating, onCancelEdit, onProcessFiles,
+    onAddFileById, onCancelUpload, onTranscribeAudio, setAspectRatio, setImageSize, onToggleGoogleSearch,
+    onToggleCodeExecution, onToggleLocalPython, onToggleUrlContext, onToggleDeepSearch, onClearChat, onOpenSettings,
+    onToggleCanvasPrompt, onTogglePinCurrentSession, onRetryLastTurn, onEditLastUserMessage, onTogglePip,
+    onToggleQuadImages, onSetThinkingLevel, setCurrentChatSettings, onOpenSidePanel,
+    onAddUserMessage, onLiveTranscript
+  ]);
+};

--- a/src/hooks/app/props/useSidebarProps.ts
+++ b/src/hooks/app/props/useSidebarProps.ts
@@ -1,0 +1,74 @@
+import { useMemo } from 'react';
+import { useAppLogic } from '../useAppLogic';
+import { getShortcutDisplay } from '../../../utils/shortcutUtils';
+import { useUIStore } from '../../../stores/uiStore';
+
+export const useSidebarProps = (logic: ReturnType<typeof useAppLogic>) => {
+  const {
+    appSettings,
+    chatState,
+    currentTheme,
+    language,
+    t,
+    setIsExportModalOpen,
+  } = logic;
+
+  const setIsHistorySidebarOpen = useUIStore((s) => s.setIsHistorySidebarOpen);
+  const setIsSettingsModalOpen = useUIStore((s) => s.setIsSettingsModalOpen);
+  const setIsPreloadedMessagesModalOpen = useUIStore((s) => s.setIsPreloadedMessagesModalOpen);
+  const isHistorySidebarOpen = useUIStore((s) => s.isHistorySidebarOpen);
+
+  return useMemo(() => ({
+    isOpen: isHistorySidebarOpen,
+    onToggle: () => setIsHistorySidebarOpen(prev => !prev),
+    sessions: chatState.savedSessions,
+    groups: chatState.savedGroups,
+    activeSessionId: chatState.activeSessionId,
+    loadingSessionIds: chatState.loadingSessionIds,
+    generatingTitleSessionIds: chatState.generatingTitleSessionIds,
+    onSelectSession: (id: string) => { chatState.loadChatSession(id); },
+    onNewChat: () => chatState.startNewChat(),
+    onDeleteSession: chatState.handleDeleteChatHistorySession,
+    onRenameSession: chatState.handleRenameSession,
+    onTogglePinSession: chatState.handleTogglePinCurrentSession,
+    onDuplicateSession: chatState.handleDuplicateSession,
+    onOpenExportModal: () => setIsExportModalOpen(true),
+    onAddNewGroup: chatState.handleAddNewGroup,
+    onDeleteGroup: chatState.handleDeleteGroup,
+    onRenameGroup: chatState.handleRenameGroup,
+    onMoveSessionToGroup: chatState.handleMoveSessionToGroup,
+    onToggleGroupExpansion: chatState.handleToggleGroupExpansion,
+    onOpenSettingsModal: () => setIsSettingsModalOpen(true),
+    onOpenScenariosModal: () => setIsPreloadedMessagesModalOpen(true),
+    t,
+    themeId: currentTheme.id,
+    language,
+    newChatShortcut: getShortcutDisplay('general.newChat', appSettings),
+  }), [
+    isHistorySidebarOpen,
+    setIsHistorySidebarOpen,
+    setIsSettingsModalOpen,
+    setIsPreloadedMessagesModalOpen,
+    chatState.savedSessions,
+    chatState.savedGroups,
+    chatState.activeSessionId,
+    chatState.loadingSessionIds,
+    chatState.generatingTitleSessionIds,
+    chatState.loadChatSession,
+    chatState.startNewChat,
+    chatState.handleDeleteChatHistorySession,
+    chatState.handleRenameSession,
+    chatState.handleTogglePinCurrentSession,
+    chatState.handleDuplicateSession,
+    chatState.handleAddNewGroup,
+    chatState.handleDeleteGroup,
+    chatState.handleRenameGroup,
+    chatState.handleMoveSessionToGroup,
+    chatState.handleToggleGroupExpansion,
+    currentTheme,
+    language,
+    t,
+    appSettings,
+    setIsExportModalOpen
+  ]);
+};

--- a/src/hooks/app/useAppLogic.ts
+++ b/src/hooks/app/useAppLogic.ts
@@ -1,0 +1,144 @@
+
+
+
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useAppSettings } from '../core/useAppSettings';
+import { useChat } from '../chat/useChat';
+import { useAppUI } from '../core/useAppUI';
+import { useAppEvents } from '../core/useAppEvents';
+import { usePictureInPicture } from '../core/usePictureInPicture';
+import { useDataManagement } from '../useDataManagement';
+import { getTranslator, applyThemeToDocument, logService } from '../../utils/appUtils';
+import { useUIStore } from '../../stores/uiStore';
+
+// Import new modularized hooks
+import { useAppInitialization } from './logic/useAppInitialization';
+import { useAppTitle } from './logic/useAppTitle';
+import { useAppSidePanel } from './logic/useAppSidePanel';
+import { useAppHandlers } from './logic/useAppHandlers';
+
+export const useAppLogic = () => {
+  const { appSettings, setAppSettings, currentTheme, language } = useAppSettings();
+  const t = useMemo(() => getTranslator(language), [language]);
+
+  // 1. Initialization
+  useAppInitialization(appSettings);
+
+  const chatState = useChat(appSettings, setAppSettings, language);
+
+  const uiState = useAppUI();
+  const setIsHistorySidebarOpen = useUIStore((s) => s.setIsHistorySidebarOpen);
+
+  // 2. Side Panel Logic
+  const { sidePanelContent, handleOpenSidePanel, handleCloseSidePanel } = useAppSidePanel(setIsHistorySidebarOpen);
+
+  // 3. PiP Logic
+  const pipState = usePictureInPicture(setIsHistorySidebarOpen);
+
+  // Sync styles to PiP window when theme changes
+  useEffect(() => {
+    if (pipState.pipWindow && pipState.pipWindow.document) {
+        applyThemeToDocument(pipState.pipWindow.document, currentTheme, appSettings);
+    }
+  }, [pipState.pipWindow, currentTheme, appSettings]);
+
+  // 4. App Events (Shortcuts, PWA)
+  const isSettingsModalOpen = useUIStore((s) => s.isSettingsModalOpen);
+  const isPreloadedMessagesModalOpen = useUIStore((s) => s.isPreloadedMessagesModalOpen);
+  const setIsLogViewerOpen = useUIStore((s) => s.setIsLogViewerOpen);
+
+  const eventsState = useAppEvents({
+    appSettings,
+    startNewChat: chatState.startNewChat,
+    handleClearCurrentChat: chatState.handleClearCurrentChat,
+    currentChatSettings: chatState.currentChatSettings,
+    handleSelectModelInHeader: chatState.handleSelectModelInHeader,
+    isSettingsModalOpen,
+    isPreloadedMessagesModalOpen,
+    setIsLogViewerOpen,
+    onTogglePip: pipState.togglePip,
+    isPipSupported: pipState.isPipSupported,
+    pipWindow: pipState.pipWindow,
+    isLoading: chatState.isLoading,
+    onStopGenerating: chatState.handleStopGenerating
+  });
+
+  const [isExportModalOpen, setIsExportModalOpen] = useState(false);
+  const [exportStatus, setExportStatus] = useState<'idle' | 'exporting'>('idle');
+
+  const activeChat = chatState.savedSessions.find(s => s.id === chatState.activeSessionId);
+  const sessionTitle = activeChat?.title || t('newChat');
+
+  // 5. Title & Timer Logic
+  useAppTitle({
+      isLoading: chatState.isLoading,
+      messages: chatState.messages,
+      language,
+      sessionTitle
+  });
+
+  // 6. Data Management
+  const dataManagement = useDataManagement({
+    appSettings,
+    setAppSettings,
+    savedSessions: chatState.savedSessions,
+    updateAndPersistSessions: chatState.updateAndPersistSessions,
+    savedGroups: chatState.savedGroups,
+    updateAndPersistGroups: chatState.updateAndPersistGroups,
+    savedScenarios: chatState.savedScenarios,
+    handleSaveAllScenarios: chatState.handleSaveAllScenarios,
+    t,
+    activeChat,
+    scrollContainerRef: chatState.scrollContainerRef,
+    currentTheme,
+    language,
+  });
+
+  const handleExportChat = useCallback(async (format: 'png' | 'html' | 'txt' | 'json') => {
+    if (!activeChat) return;
+    setExportStatus('exporting');
+    try {
+      await dataManagement.exportChatLogic(format);
+    } catch (error) {
+        logService.error(`Chat export failed (format: ${format})`, { error });
+        alert(`Export failed: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+        setExportStatus('idle');
+        setIsExportModalOpen(false);
+    }
+  }, [activeChat, dataManagement]);
+
+  // 7. Core Handlers
+  const {
+      handleSaveSettings,
+      handleLoadCanvasPromptAndSave,
+      handleToggleBBoxMode,
+      handleToggleGuideMode,
+      handleSuggestionClick,
+      handleSetThinkingLevel,
+      getCurrentModelDisplayName
+  } = useAppHandlers({
+      setAppSettings,
+      activeSessionId: chatState.activeSessionId,
+      setCurrentChatSettings: chatState.setCurrentChatSettings,
+      currentChatSettings: chatState.currentChatSettings,
+      appSettings,
+      chatState,
+      t
+  });
+
+  return {
+    appSettings, setAppSettings, currentTheme, language, t,
+    chatState, uiState, pipState, eventsState, dataManagement,
+    sidePanelContent, handleOpenSidePanel, handleCloseSidePanel,
+    isExportModalOpen, setIsExportModalOpen, exportStatus, handleExportChat,
+    activeChat, sessionTitle,
+    handleSaveSettings,
+    handleLoadCanvasPromptAndSave,
+    handleToggleBBoxMode,
+    handleToggleGuideMode,
+    handleSuggestionClick,
+    handleSetThinkingLevel,
+    getCurrentModelDisplayName
+  };
+};

--- a/src/hooks/chat/useChatState.ts
+++ b/src/hooks/chat/useChatState.ts
@@ -1,0 +1,98 @@
+
+import { useMemo } from 'react';
+import { AppSettings } from '../../types';
+import { useChatStore } from '../../stores/chatStore';
+
+export const useChatState = (appSettings: AppSettings) => {
+
+    const activeSessionId = useChatStore((s) => s.activeSessionId);
+    const savedSessions = useChatStore((s) => s.savedSessions);
+    const activeMessages = useChatStore((s) => s.activeMessages);
+    const editingMessageId = useChatStore((s) => s.editingMessageId);
+    const editMode = useChatStore((s) => s.editMode);
+    const commandedInput = useChatStore((s) => s.commandedInput);
+    const loadingSessionIds = useChatStore((s) => s.loadingSessionIds);
+    const generatingTitleSessionIds = useChatStore((s) => s.generatingTitleSessionIds);
+    const selectedFiles = useChatStore((s) => s.selectedFiles);
+    const appFileError = useChatStore((s) => s.appFileError);
+    const isAppProcessingFile = useChatStore((s) => s.isAppProcessingFile);
+    const aspectRatio = useChatStore((s) => s.aspectRatio);
+    const imageSize = useChatStore((s) => s.imageSize);
+    const ttsMessageId = useChatStore((s) => s.ttsMessageId);
+    const isSwitchingModel = useChatStore((s) => s.isSwitchingModel);
+    const scrollContainerRef = useChatStore((s) => s.scrollContainerRef);
+
+    // --- Computed State ---
+
+    const activeChat = useMemo(() => {
+        const metadata = savedSessions.find(s => s.id === activeSessionId);
+        if (metadata) {
+            return { ...metadata, messages: activeMessages };
+        }
+        return undefined;
+    }, [savedSessions, activeSessionId, activeMessages]);
+
+    const currentChatSettings = useMemo(() => activeChat?.settings || appSettings, [activeChat, appSettings]);
+
+    const isLoading = useMemo(() =>
+        loadingSessionIds.has(activeSessionId ?? ''),
+    [loadingSessionIds, activeSessionId]);
+
+    // Aggregate everything into a single return object
+    return {
+        // Session Data
+        savedSessions,
+        setSavedSessions: useChatStore.getState().setSavedSessions,
+        savedGroups: useChatStore((s) => s.savedGroups),
+        setSavedGroups: useChatStore.getState().setSavedGroups,
+        activeSessionId,
+        setActiveSessionId: useChatStore.getState().setActiveSessionId,
+        activeMessages,
+        setActiveMessages: useChatStore.getState().setActiveMessages,
+        messages: activeMessages,
+
+        // Auxiliary State
+        editingMessageId,
+        setEditingMessageId: useChatStore.getState().setEditingMessageId,
+        editMode,
+        setEditMode: useChatStore.getState().setEditMode,
+        commandedInput,
+        setCommandedInput: useChatStore.getState().setCommandedInput,
+        loadingSessionIds,
+        setLoadingSessionIds: useChatStore.getState().setLoadingSessionIds,
+        generatingTitleSessionIds,
+        setGeneratingTitleSessionIds: useChatStore.getState().setGeneratingTitleSessionIds,
+        activeJobs: useChatStore.getState()._activeJobs,
+        selectedFiles,
+        setSelectedFiles: useChatStore.getState().setSelectedFiles,
+        appFileError,
+        setAppFileError: useChatStore.getState().setAppFileError,
+        isAppProcessingFile,
+        setIsAppProcessingFile: useChatStore.getState().setIsAppProcessingFile,
+        aspectRatio,
+        setAspectRatio: useChatStore.getState().setAspectRatio,
+        imageSize,
+        setImageSize: useChatStore.getState().setImageSize,
+        ttsMessageId,
+        setTtsMessageId: useChatStore.getState().setTtsMessageId,
+        isSwitchingModel,
+        setIsSwitchingModel: useChatStore.getState().setIsSwitchingModel,
+        userScrolledUp: useChatStore.getState()._userScrolledUp,
+        fileDraftsRef: useChatStore.getState()._fileDrafts,
+        scrollContainerRef,
+        setScrollContainerRef: useChatStore.getState().setScrollContainerRef,
+
+        // Persistence
+        updateAndPersistSessions: useChatStore.getState().updateAndPersistSessions,
+        updateAndPersistGroups: useChatStore.getState().updateAndPersistGroups,
+        refreshSessions: useChatStore.getState().refreshSessions,
+        refreshGroups: useChatStore.getState().refreshGroups,
+        setSessionLoading: useChatStore.getState().setSessionLoading,
+
+        // Computed
+        activeChat,
+        currentChatSettings,
+        isLoading,
+        setCurrentChatSettings: useChatStore.getState().setCurrentChatSettings,
+    };
+};

--- a/src/hooks/core/useAppSettings.ts
+++ b/src/hooks/core/useAppSettings.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useSettingsStore } from '../../stores/settingsStore';
+import { applyThemeToDocument } from '../../utils/appUtils';
+
+export const useAppSettings = () => {
+    const appSettings = useSettingsStore((s) => s.appSettings);
+    const setAppSettings = useSettingsStore((s) => s.setAppSettings);
+    const currentTheme = useSettingsStore((s) => s.currentTheme);
+    const language = useSettingsStore((s) => s.language);
+    const loadSettings = useSettingsStore((s) => s.loadSettings);
+
+    // Initial load
+    useEffect(() => {
+        loadSettings();
+    }, [loadSettings]);
+
+    // Apply theme to DOM when settings change
+    useEffect(() => {
+        applyThemeToDocument(document, currentTheme, appSettings);
+    }, [appSettings, currentTheme]);
+
+    return { appSettings, setAppSettings, currentTheme, language };
+};

--- a/src/hooks/core/useAppUI.ts
+++ b/src/hooks/core/useAppUI.ts
@@ -1,0 +1,56 @@
+import React, { useCallback, useRef } from 'react';
+import { useUIStore } from '../../stores/uiStore';
+
+export const useAppUI = () => {
+  const isSettingsModalOpen = useUIStore((s) => s.isSettingsModalOpen);
+  const isPreloadedMessagesModalOpen = useUIStore((s) => s.isPreloadedMessagesModalOpen);
+  const isHistorySidebarOpen = useUIStore((s) => s.isHistorySidebarOpen);
+  const isLogViewerOpen = useUIStore((s) => s.isLogViewerOpen);
+  const setIsSettingsModalOpen = useUIStore((s) => s.setIsSettingsModalOpen);
+  const setIsPreloadedMessagesModalOpen = useUIStore((s) => s.setIsPreloadedMessagesModalOpen);
+  const setIsHistorySidebarOpen = useUIStore((s) => s.setIsHistorySidebarOpen);
+  const setIsLogViewerOpen = useUIStore((s) => s.setIsLogViewerOpen);
+
+  const touchStartRef = useRef({ x: 0, y: 0 });
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    const firstTouch = e.touches[0];
+    if (firstTouch) {
+        touchStartRef.current = { x: firstTouch.clientX, y: firstTouch.clientY };
+    }
+  }, []);
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+      const lastTouch = e.changedTouches[0];
+      if (!lastTouch) return;
+
+      const deltaX = lastTouch.clientX - touchStartRef.current.x;
+      const deltaY = lastTouch.clientY - touchStartRef.current.y;
+      const swipeThreshold = 50;
+      const edgeThreshold = 40;
+
+      if (Math.abs(deltaX) < Math.abs(deltaY)) {
+          return;
+      }
+
+      if (deltaX > swipeThreshold && !isHistorySidebarOpen && touchStartRef.current.x < edgeThreshold) {
+          setIsHistorySidebarOpen(true);
+      }
+      else if (deltaX < -swipeThreshold && isHistorySidebarOpen) {
+          setIsHistorySidebarOpen(false);
+      }
+  }, [isHistorySidebarOpen, setIsHistorySidebarOpen]);
+
+  return {
+    isSettingsModalOpen,
+    setIsSettingsModalOpen,
+    isPreloadedMessagesModalOpen,
+    setIsPreloadedMessagesModalOpen,
+    isHistorySidebarOpen,
+    setIsHistorySidebarOpen,
+    isLogViewerOpen,
+    setIsLogViewerOpen,
+    handleTouchStart,
+    handleTouchEnd,
+  };
+};

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,0 +1,397 @@
+import { create } from 'zustand';
+import { SavedChatSession, ChatGroup, ChatMessage, UploadedFile, InputCommand, ChatSettings } from '../types';
+import { dbService } from '../utils/db';
+import { logService, rehydrateSessionFiles } from '../utils/appUtils';
+import { ACTIVE_CHAT_SESSION_ID_KEY } from '../constants/appConstants';
+import { SyncMessage } from '../hooks/core/useMultiTabSync';
+
+// ── Internal refs (not in Zustand state to avoid re-renders) ──
+// Typed as MutableRefObject so downstream hooks see the correct shape
+const _activeJobs: { current: Map<string, AbortController> } = { current: new Map() };
+const _userScrolledUp: { current: boolean } = { current: false };
+const _fileDrafts: { current: Record<string, UploadedFile[]> } = { current: {} };
+const _localLoadingSessionIds = new Set<string>();
+let _isDirty = false;
+
+// ── BroadcastChannel for multi-tab sync ──
+let syncChannel: BroadcastChannel | null = null;
+function getSyncChannel(): BroadcastChannel {
+  if (!syncChannel) {
+    syncChannel = new BroadcastChannel('all_model_chat_sync_v1');
+  }
+  return syncChannel;
+}
+
+function broadcast(msg: SyncMessage) {
+  try { getSyncChannel().postMessage(msg); } catch {}
+}
+
+// ── Sort helper ──
+function sortSessions(sessions: SavedChatSession[]) {
+  sessions.sort((a, b) => {
+    if (a.isPinned && !b.isPinned) return -1;
+    if (!a.isPinned && b.isPinned) return 1;
+    return b.timestamp - a.timestamp;
+  });
+}
+
+// ── URL & sessionStorage sync ──
+function syncActiveSessionToUrl(activeSessionId: string | null) {
+  if (activeSessionId) {
+    try { sessionStorage.setItem(ACTIVE_CHAT_SESSION_ID_KEY, activeSessionId); } catch {}
+    const targetPath = `/chat/${activeSessionId}`;
+    try {
+      if (window.location.pathname !== targetPath) {
+        if (window.location.pathname.startsWith('/chat/')) {
+          window.history.replaceState({ sessionId: activeSessionId }, '', targetPath);
+        } else {
+          window.history.pushState({ sessionId: activeSessionId }, '', targetPath);
+        }
+      }
+    } catch {}
+  } else {
+    try { sessionStorage.removeItem(ACTIVE_CHAT_SESSION_ID_KEY); } catch {}
+    try {
+      if (window.location.pathname !== '/' && !window.location.pathname.startsWith('/chat/')) {
+        window.history.pushState({}, '', '/');
+      }
+    } catch {}
+  }
+}
+
+// ── Store types ──
+interface ChatState {
+  // Session Data
+  savedSessions: SavedChatSession[];
+  savedGroups: ChatGroup[];
+  activeSessionId: string | null;
+  activeMessages: ChatMessage[];
+
+  // Auxiliary
+  editingMessageId: string | null;
+  editMode: 'update' | 'resend';
+  commandedInput: InputCommand | null;
+  loadingSessionIds: Set<string>;
+  generatingTitleSessionIds: Set<string>;
+  selectedFiles: UploadedFile[];
+  appFileError: string | null;
+  isAppProcessingFile: boolean;
+  aspectRatio: string;
+  imageSize: string;
+  ttsMessageId: string | null;
+  isSwitchingModel: boolean;
+  scrollContainerRef: React.RefObject<HTMLDivElement> | null;
+
+  // Read-only refs (accessed via helpers, not reactive)
+  _activeJobs: { current: Map<string, AbortController> };
+  _userScrolledUp: { current: boolean };
+  _fileDrafts: { current: Record<string, UploadedFile[]> };
+}
+
+interface ChatActions {
+  // Session setters
+  setSavedSessions: (v: SavedChatSession[] | ((p: SavedChatSession[]) => SavedChatSession[])) => void;
+  setSavedGroups: (v: ChatGroup[] | ((p: ChatGroup[]) => ChatGroup[])) => void;
+  setActiveSessionId: (id: string | null) => void;
+  setActiveMessages: (v: ChatMessage[] | ((p: ChatMessage[]) => ChatMessage[])) => void;
+
+  // Auxiliary setters
+  setEditingMessageId: (id: string | null) => void;
+  setEditMode: (mode: 'update' | 'resend') => void;
+  setCommandedInput: (cmd: InputCommand | null) => void;
+  setLoadingSessionIds: (v: Set<string> | ((p: Set<string>) => Set<string>)) => void;
+  setGeneratingTitleSessionIds: (v: Set<string> | ((p: Set<string>) => Set<string>)) => void;
+  setSelectedFiles: (v: UploadedFile[] | ((p: UploadedFile[]) => UploadedFile[])) => void;
+  setAppFileError: (v: string | null) => void;
+  setIsAppProcessingFile: (v: boolean) => void;
+  setAspectRatio: (v: string) => void;
+  setImageSize: (v: string) => void;
+  setTtsMessageId: (v: string | null) => void;
+  setIsSwitchingModel: (v: boolean) => void;
+  setScrollContainerRef: (ref: React.RefObject<HTMLDivElement> | null) => void;
+
+  // Persistence
+  updateAndPersistSessions: (updater: (prev: SavedChatSession[]) => SavedChatSession[], options?: { persist?: boolean }) => void;
+  updateAndPersistGroups: (updater: (prev: ChatGroup[]) => ChatGroup[]) => void;
+  refreshSessions: () => Promise<void>;
+  refreshGroups: () => Promise<void>;
+  setSessionLoading: (sessionId: string, isLoading: boolean) => void;
+
+  // Computed helpers (call getState inside)
+  setCurrentChatSettings: (updater: (prev: ChatSettings) => ChatSettings) => void;
+}
+
+export const useChatStore = create<ChatState & ChatActions>((set, get) => ({
+  // ── Initial State ──
+  savedSessions: [],
+  savedGroups: [],
+  activeSessionId: null,
+  activeMessages: [],
+
+  editingMessageId: null,
+  editMode: 'resend',
+  commandedInput: null,
+  loadingSessionIds: new Set<string>(),
+  generatingTitleSessionIds: new Set<string>(),
+  selectedFiles: [],
+  appFileError: null,
+  isAppProcessingFile: false,
+  aspectRatio: '1:1',
+  imageSize: '1K',
+  ttsMessageId: null,
+  isSwitchingModel: false,
+  scrollContainerRef: null,
+
+  _activeJobs,
+  _userScrolledUp,
+  _fileDrafts,
+
+  // ── Session Setters ──
+  setSavedSessions: (v) => set((s) => ({
+    savedSessions: typeof v === 'function' ? v(s.savedSessions) : v,
+  })),
+
+  setSavedGroups: (v) => set((s) => ({
+    savedGroups: typeof v === 'function' ? v(s.savedGroups) : v,
+  })),
+
+  setActiveSessionId: (id) => {
+    set({ activeSessionId: id });
+    syncActiveSessionToUrl(id);
+  },
+
+  setActiveMessages: (v) => set((s) => ({
+    activeMessages: typeof v === 'function' ? v(s.activeMessages) : v,
+  })),
+
+  // ── Auxiliary Setters ──
+  setEditingMessageId: (id) => set({ editingMessageId: id }),
+  setEditMode: (mode) => set({ editMode: mode }),
+  setCommandedInput: (cmd) => set({ commandedInput: cmd }),
+  setLoadingSessionIds: (v) => set((s) => ({
+    loadingSessionIds: typeof v === 'function' ? v(s.loadingSessionIds) : v,
+  })),
+  setGeneratingTitleSessionIds: (v) => set((s) => ({
+    generatingTitleSessionIds: typeof v === 'function' ? v(s.generatingTitleSessionIds) : v,
+  })),
+  setSelectedFiles: (v) => set((s) => ({
+    selectedFiles: typeof v === 'function' ? v(s.selectedFiles) : v,
+  })),
+  setAppFileError: (v) => set({ appFileError: v }),
+  setIsAppProcessingFile: (v) => set({ isAppProcessingFile: v }),
+  setAspectRatio: (v) => set({ aspectRatio: v }),
+  setImageSize: (v) => set({ imageSize: v }),
+  setTtsMessageId: (v) => set({ ttsMessageId: v }),
+  setIsSwitchingModel: (v) => set({ isSwitchingModel: v }),
+  setScrollContainerRef: (ref) => set({ scrollContainerRef: ref }),
+
+  // ── Persistence Actions ──
+  refreshSessions: async () => {
+    try {
+      const metadataList = await dbService.getAllSessionMetadata();
+      const { activeSessionId, setActiveMessages, setSavedSessions } = get();
+
+      if (activeSessionId) {
+        const fullActiveSession = await dbService.getSession(activeSessionId);
+        if (fullActiveSession) {
+          const rehydrated = rehydrateSessionFiles(fullActiveSession);
+          setActiveMessages(rehydrated.messages);
+        }
+      }
+
+      sortSessions(metadataList);
+      setSavedSessions(metadataList);
+    } catch (e) {
+      logService.error('Failed to refresh sessions from DB', { error: e });
+    }
+  },
+
+  refreshGroups: async () => {
+    try {
+      const groups = await dbService.getAllGroups();
+      set({ savedGroups: groups });
+    } catch (e) {
+      logService.error('Failed to refresh groups from DB', { error: e });
+    }
+  },
+
+  setSessionLoading: (sessionId, isLoading) => {
+    if (isLoading) {
+      _localLoadingSessionIds.add(sessionId);
+    } else {
+      _localLoadingSessionIds.delete(sessionId);
+    }
+
+    set((s) => {
+      const next = new Set(s.loadingSessionIds);
+      if (isLoading) next.add(sessionId);
+      else next.delete(sessionId);
+      return { loadingSessionIds: next };
+    });
+
+    broadcast({ type: 'SESSION_LOADING', sessionId, isLoading });
+  },
+
+  updateAndPersistSessions: (updater, options = {}) => {
+    const { persist = true } = options;
+    const { savedSessions, activeSessionId, activeMessages } = get();
+
+    // 1. Reconstruct "Virtual" Full State
+    const virtualFullSessions = savedSessions.map(s => {
+      if (s.id === activeSessionId) {
+        return { ...s, messages: activeMessages };
+      }
+      return s;
+    });
+
+    // 2. Run Updater
+    const newFullSessions = updater(virtualFullSessions);
+
+    // 3. Sort
+    sortSessions(newFullSessions);
+
+    // 4. Update Active Messages if changed
+    if (activeSessionId) {
+      const newActiveSession = newFullSessions.find(s => s.id === activeSessionId);
+      if (newActiveSession && newActiveSession.messages !== activeMessages) {
+        set({ activeMessages: newActiveSession.messages });
+      }
+    }
+
+    // 5. Persist
+    if (persist) {
+      const updates: Promise<void>[] = [];
+      const newSessionsMap = new Map(newFullSessions.map(s => [s.id, s]));
+      const modifiedSessionIds: string[] = [];
+
+      newFullSessions.forEach(session => {
+        const prevSession = virtualFullSessions.find(ps => ps.id === session.id);
+        if (prevSession !== session) {
+          updates.push(dbService.saveSession(session));
+          modifiedSessionIds.push(session.id);
+        }
+      });
+
+      savedSessions.forEach(session => {
+        if (!newSessionsMap.has(session.id)) {
+          updates.push(dbService.deleteSession(session.id));
+        }
+      });
+
+      if (updates.length > 0) {
+        Promise.all(updates).then(() => {
+          if (modifiedSessionIds.length === 1) {
+            broadcast({ type: 'SESSION_CONTENT_UPDATED', sessionId: modifiedSessionIds[0] });
+          } else {
+            broadcast({ type: 'SESSIONS_UPDATED' });
+          }
+        }).catch(e => logService.error('Failed to persist session updates', { error: e }));
+      }
+    }
+
+    // 6. Return Metadata Only (strip messages)
+    const metadataOnly = newFullSessions.map(s => {
+      if (s.messages && s.messages.length === 0) return s;
+      const { messages, ...rest } = s;
+      return { ...rest, messages: [] };
+    });
+
+    set({ savedSessions: metadataOnly });
+  },
+
+  updateAndPersistGroups: (updater) => {
+    const { savedGroups } = get();
+    const newGroups = updater(savedGroups);
+    dbService.setAllGroups(newGroups)
+      .then(() => broadcast({ type: 'GROUPS_UPDATED' }))
+      .catch(e => logService.error('Failed to persist group updates', { error: e }));
+    set({ savedGroups: newGroups });
+  },
+
+  setCurrentChatSettings: (updater) => {
+    const { activeSessionId } = get();
+    if (!activeSessionId) return;
+    get().updateAndPersistSessions(prevSessions =>
+      prevSessions.map(s =>
+        s.id === activeSessionId
+          ? { ...s, settings: updater(s.settings) }
+          : s
+      )
+    );
+  },
+}));
+
+// ── Setup BroadcastChannel listener (once) ──
+if (typeof BroadcastChannel !== 'undefined') {
+  const channel = getSyncChannel();
+  const originalOnMessage = channel.onmessage;
+
+  channel.onmessage = (event: MessageEvent<SyncMessage>) => {
+    // Call original handler if it exists (from settings store or other)
+    if (originalOnMessage) {
+      originalOnMessage.call(channel, event);
+    }
+
+    const msg = event.data;
+    const store = useChatStore;
+
+    switch (msg.type) {
+      case 'SETTINGS_UPDATED':
+      case 'SESSIONS_UPDATED':
+        if (document.hidden) {
+          _isDirty = true;
+        } else {
+          store.getState().refreshSessions();
+        }
+        break;
+      case 'GROUPS_UPDATED':
+        if (document.hidden) {
+          _isDirty = true;
+        } else {
+          store.getState().refreshGroups();
+        }
+        break;
+      case 'SESSION_CONTENT_UPDATED': {
+        if (_localLoadingSessionIds.has(msg.sessionId)) return;
+        if (document.hidden) {
+          _isDirty = true;
+          return;
+        }
+        const { activeSessionId } = store.getState();
+        if (msg.sessionId === activeSessionId) {
+          dbService.getSession(msg.sessionId).then(s => {
+            if (s) {
+              const rehydrated = rehydrateSessionFiles(s);
+              store.getState().setActiveMessages(rehydrated.messages);
+              store.getState().setSavedSessions(prev =>
+                prev.map(old => old.id === msg.sessionId ? { ...rehydrated, messages: [] } : old)
+              );
+            }
+          });
+        } else {
+          store.getState().refreshSessions();
+        }
+        break;
+      }
+      case 'SESSION_LOADING': {
+        store.getState().setLoadingSessionIds(prev => {
+          const next = new Set(prev);
+          if (msg.isLoading) next.add(msg.sessionId);
+          else next.delete(msg.sessionId);
+          return next;
+        });
+        break;
+      }
+    }
+  };
+
+  // Visibility change handler
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible' && _isDirty) {
+      logService.info('[Sync] Tab visible, syncing pending updates from DB.');
+      useChatStore.getState().refreshSessions();
+      useChatStore.getState().refreshGroups();
+      _isDirty = false;
+    }
+  });
+}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1,0 +1,125 @@
+import { create } from 'zustand';
+import { AppSettings } from '../types';
+import { Theme } from '../types/theme';
+import { DEFAULT_APP_SETTINGS, DEFAULT_FILES_API_CONFIG } from '../constants/appConstants';
+import { AVAILABLE_THEMES, DEFAULT_THEME_ID } from '../constants/themeConstants';
+import { logService } from '../utils/appUtils';
+import { dbService } from '../utils/db';
+
+interface SettingsState {
+  appSettings: AppSettings;
+  currentTheme: Theme;
+  language: 'en' | 'zh';
+  isSettingsLoaded: boolean;
+}
+
+interface SettingsActions {
+  setAppSettings: (v: AppSettings | ((prev: AppSettings) => AppSettings)) => void;
+  loadSettings: () => Promise<void>;
+  broadcastSettingsUpdate: () => void;
+}
+
+function resolveThemeId(themeId: string): 'onyx' | 'pearl' {
+  if (themeId === 'system') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'onyx' : 'pearl';
+  }
+  return themeId as 'onyx' | 'pearl';
+}
+
+function resolveLanguage(language: string): 'en' | 'zh' {
+  const settingLang = language || 'system';
+  if (settingLang === 'system') {
+    const browserLang = navigator.language.toLowerCase();
+    return browserLang.startsWith('zh') ? 'zh' : 'en';
+  }
+  return settingLang as 'en' | 'zh';
+}
+
+function computeTheme(themeId: string): Theme {
+  const resolvedId = resolveThemeId(themeId);
+  return AVAILABLE_THEMES.find(t => t.id === resolvedId) || AVAILABLE_THEMES.find(t => t.id === DEFAULT_THEME_ID)!;
+}
+
+// BroadcastChannel singleton for settings sync
+let settingsChannel: BroadcastChannel | null = null;
+function getSettingsChannel(): BroadcastChannel {
+  if (!settingsChannel) {
+    settingsChannel = new BroadcastChannel('all_model_chat_sync_v1');
+  }
+  return settingsChannel;
+}
+
+export const useSettingsStore = create<SettingsState & SettingsActions>((set) => ({
+  appSettings: DEFAULT_APP_SETTINGS,
+  currentTheme: computeTheme(DEFAULT_APP_SETTINGS.themeId),
+  language: resolveLanguage(DEFAULT_APP_SETTINGS.language),
+  isSettingsLoaded: false,
+
+  setAppSettings: (v) => {
+    set((state) => {
+      const next = typeof v === 'function' ? v(state.appSettings) : v;
+      const currentTheme = computeTheme(next.themeId);
+      const language = resolveLanguage(next.language);
+
+      // Persist to IndexedDB
+      if (state.isSettingsLoaded) {
+        dbService.setAppSettings(next)
+          .then(() => getSettingsChannel().postMessage({ type: 'SETTINGS_UPDATED' }))
+          .catch((e) => logService.error('Failed to save settings', { error: e }));
+      }
+
+      return { appSettings: next, currentTheme, language };
+    });
+  },
+
+  loadSettings: async () => {
+    try {
+      const storedSettings = await dbService.getAppSettings();
+      if (storedSettings) {
+        const newSettings = { ...DEFAULT_APP_SETTINGS, ...storedSettings };
+        if (storedSettings.filesApiConfig) {
+          newSettings.filesApiConfig = { ...DEFAULT_FILES_API_CONFIG, ...storedSettings.filesApiConfig };
+        }
+        set({
+          appSettings: newSettings,
+          currentTheme: computeTheme(newSettings.themeId),
+          language: resolveLanguage(newSettings.language),
+          isSettingsLoaded: true,
+        });
+      } else {
+        set({ isSettingsLoaded: true });
+      }
+    } catch (error) {
+      logService.error('Failed to load settings from IndexedDB', { error });
+      set({ isSettingsLoaded: true });
+    }
+  },
+
+  broadcastSettingsUpdate: () => {
+    getSettingsChannel().postMessage({ type: 'SETTINGS_UPDATED' });
+  },
+}));
+
+// Setup BroadcastChannel listener for multi-tab settings sync
+if (typeof BroadcastChannel !== 'undefined') {
+  const channel = getSettingsChannel();
+  channel.onmessage = (event) => {
+    const msg = event.data;
+    if (msg.type === 'SETTINGS_UPDATED') {
+      logService.info('[Sync] Reloading settings from DB');
+      useSettingsStore.getState().loadSettings();
+    }
+  };
+}
+
+// Listen for system theme changes when using 'system' theme
+if (typeof window !== 'undefined') {
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  mediaQuery.addEventListener('change', () => {
+    const { appSettings } = useSettingsStore.getState();
+    if (appSettings.themeId === 'system') {
+      const currentTheme = computeTheme(appSettings.themeId);
+      useSettingsStore.setState({ currentTheme });
+    }
+  });
+}

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand';
+
+interface UIState {
+  isSettingsModalOpen: boolean;
+  isPreloadedMessagesModalOpen: boolean;
+  isHistorySidebarOpen: boolean;
+  isLogViewerOpen: boolean;
+}
+
+interface UIActions {
+  setIsSettingsModalOpen: (v: boolean | ((p: boolean) => boolean)) => void;
+  setIsPreloadedMessagesModalOpen: (v: boolean | ((p: boolean) => boolean)) => void;
+  setIsHistorySidebarOpen: (v: boolean | ((p: boolean) => boolean)) => void;
+  setIsLogViewerOpen: (v: boolean | ((p: boolean) => boolean)) => void;
+  toggleHistorySidebar: () => void;
+}
+
+export const useUIStore = create<UIState & UIActions>((set) => ({
+  isSettingsModalOpen: false,
+  isPreloadedMessagesModalOpen: false,
+  isHistorySidebarOpen: window.innerWidth >= 768,
+  isLogViewerOpen: false,
+
+  setIsSettingsModalOpen: (v) =>
+    set((s) => ({
+      isSettingsModalOpen: typeof v === 'function' ? v(s.isSettingsModalOpen) : v,
+    })),
+  setIsPreloadedMessagesModalOpen: (v) =>
+    set((s) => ({
+      isPreloadedMessagesModalOpen:
+        typeof v === 'function' ? v(s.isPreloadedMessagesModalOpen) : v,
+    })),
+  setIsHistorySidebarOpen: (v) =>
+    set((s) => ({
+      isHistorySidebarOpen:
+        typeof v === 'function' ? v(s.isHistorySidebarOpen) : v,
+    })),
+  setIsLogViewerOpen: (v) =>
+    set((s) => ({
+      isLogViewerOpen: typeof v === 'function' ? v(s.isLogViewerOpen) : v,
+    })),
+  toggleHistorySidebar: () =>
+    set((s) => ({ isHistorySidebarOpen: !s.isHistorySidebarOpen })),
+}));


### PR DESCRIPTION
## Summary
- 创建 3 个 Zustand store（uiStore、settingsStore、chatStore）替代 React useState + props drilling
- 重写 useChatState 从 useChatStore 读取状态，删除旧 hooks（useChatAuxiliaryState、useSessionData、useSessionPersistence）
- 渐进式 3 阶段迁移，每阶段可独立验证

## Test plan
- [x] TypeScript 编译通过（205 错误，与迁移前基线一致）
- [x] Vite build 成功
- [x] 13 个测试全部通过
- [ ] 手动验证：新建会话、发送消息、编辑、重试、删除、历史记录切换

🤖 Generated with [Claude Code](https://claude.com/claude-code)